### PR TITLE
Documenter la gouvernance de l'intégration de la blocklist Data-Shield

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,91 +1,119 @@
 # MODÈLE DE CONFORMITÉ GRC - Document pour l'intégration de la Data-Shield IPv4 Blocklist
-Version : 0.8
+Version : 1.0
 
-- ***Propriétaire : Laurent Minne***
-- ***Contributeur :***
+- ***Propriétaire : Laurent Minne (Mainteneur Data-Shield)***
+- ***Contributeurs clés :*** Équipe Opérations Sécurité, Équipe Réseau, Responsable Conformité IT
 
 # Introduction
 
 ### Objectif
-- Expliquer l'objectif du document et l'importance de l'intégration de la Blocklist pour la sécurité de l'entreprise.
+- Décrire les politiques, responsabilités et contrôles permettant d'intégrer la Data-Shield IPv4 Blocklist comme source de renseignement de menace protégeant l'infrastructure réseau de l'entreprise. La liste alimente les pare-feux et systèmes de prévention pour bloquer automatiquement les adresses IP identifiées comme malveillantes à partir du réseau de 36 leurres Data-Shield mis à jour toutes les 24 heures.【F:README.md†L12-L31】
 
 ### Portée
-- Définir la portée du projet, y compris les systèmes et les réseaux qui seront concernés.
+- Ce document couvre la consommation sécurisée de la blocklist (versions complète et segmentées) dans les pare-feux Fortinet, Check Point, Palo Alto, OPNsense, Stormshield, F5 et infrastructures IPTables, ainsi que les processus internes de validation, de déploiement automatisé et de suivi continu des 9 240 IP malicieuses collectées quotidiennement.【F:README.md†L33-L82】
 
 # Cadre de gouvernance
 
 ### Déclaration de politique générale
-- Présentez les grandes lignes des politiques qui régissent l'intégration de la Blocklist.
+- La blocklist Data-Shield doit être intégrée comme flux externe approuvé, synchronisé toutes les 24 heures, avec conservation locale limitée à 60 jours. Toute modification des règles d’ingestion ou de distribution doit être approuvée par le Responsable Sécurité Systèmes d’Information (RSSI) et documentée dans le référentiel de configuration des pare-feux. La politique impose la vérification de l’intégrité du flux, la traçabilité des mises à jour et la possibilité de désactivation contrôlée en cas d’incident.【F:README.md†L20-L43】【F:README.md†L84-L113】
 
 ### Rôles et responsabilités
-- Utilisez le modèle RACI pour définir les rôles et les responsabilités.
+- Le modèle RACI défini en annexe précise :
+  - **Laurent Minne (Mainteneur)** : responsable de la qualité du flux, publication quotidienne et notification des changements majeurs.
+  - **Équipe Opérations Sécurité** : responsable opérationnel du déploiement sur les pare-feux, approbateur des changements de règles et point focal en astreinte.
+  - **Équipe Réseau** : consultée pour l’ingénierie de routage, segmentation et validation des performances.
+  - **Responsable Conformité IT** : consulté pour l’alignement aux normes (ISO 27001, NIS2) et informé des rapports de suivi.
+  - **Direction Cybersécurité** : informée des indicateurs de réduction des attaques et des incidents associés.
 
 # Évaluation des risques
 
 ### Identifier les risques
-- Énumérer les risques potentiels associés à l'intégration de la Blocklist.
+- Risque de faux positifs entraînant le blocage de clients légitimes.
+- Risque d’indisponibilité ou de corruption du flux (perte d’accès GitHub, altération du fichier).
+- Risque de dérive de configuration lors de la mise à jour automatisée des pare-feux.
+- Risque de non-conformité réglementaire liée au traitement d’adresses IP (données personnelles).
+- Risque de retard d’intégration entraînant une exposition prolongée aux menaces.
 
 ### Analyse des risques
-- Analysez la probabilité et l'impact de chaque risque identifié.
+- **Faux positifs** : probabilité faible grâce à la validation manuelle des IP, impact moyen (perturbation de service).
+- **Indisponibilité du flux** : probabilité moyenne (dépendance GitHub), impact élevé (perte de protection actualisée).
+- **Dérive de configuration** : probabilité moyenne (scripts d’automatisation), impact élevé (rupture de service ou fail-open).
+- **Non-conformité réglementaire** : probabilité faible, impact élevé (sanctions GDPR/NIS2).
+- **Retard d’intégration** : probabilité moyenne (processus change), impact moyen (fenêtre d’exposition accrue).
 
 ### Atténuation des risques
-- Proposer des stratégies d'atténuation pour chaque risque (Tests, contrôles, etc.)
+- Mettre en place une liste de contournement et un processus d’exclusion rapide pour les IP légitimes signalées par le support client.
+- Surveiller la disponibilité GitHub via un job de supervision, maintenir un miroir interne signé de la blocklist et vérifier l’empreinte SHA256 avant déploiement.
+- Utiliser un pipeline d’intégration continue avec environnement de test réseau et validation par l’équipe Réseau avant mise en production ; activer le versionnement des configurations.
+- Documenter le fondement légitime du traitement d’IP (sécurité réseau) et appliquer une rétention locale inférieure à 60 jours conforme à la politique de Data-Shield ; intégrer la procédure dans le registre GDPR.
+- Automatiser les déploiements quotidiens avec alertes en cas d’échec et tenir un journal de contrôle attestant du respect de la fréquence de 24 heures.
 
 # Exigences en matière de conformité
 
 ### Conformité réglementaire
-- Veillez à ce que l'intégration soit conforme aux réglementations et normes applicables (ISO27001, NIS2, etc.).
+- S’aligner sur les contrôles ISO/IEC 27001 Annexe A (A.8.16 Surveillance, A.5.7 Partenariats externes) en documentant l’usage du flux Data-Shield comme mesure de sécurité. Respecter les obligations NIS2 concernant la détection et la prévention des cybermenaces, et garantir la conformité GDPR pour le traitement d’adresses IP en s’appuyant sur l’intérêt légitime de sécurité et la limitation de conservation à 60 jours.【F:README.md†L45-L65】
 
 ### Conformité interne
-- Alignez la mise en œuvre sur les politiques et procédures internes (PSSI, instructions, etc.).
+- Aligner la mise en œuvre sur la Politique de Sécurité des Systèmes d’Information (PSSI) et sur les procédures de gestion des changements réseau. Chaque mise à jour doit être enregistrée dans l’outil ITSM, revue par le Change Advisory Board (CAB) sécurité et validée par le RSSI ; les procédures de rollback doivent être testées trimestriellement.
 
 # Plan d'intégration
 
 ### Calendrier du projet
-- Fournissez un calendrier pour le processus d'intégration.
+- **Semaine 1** : cadrage, revue des besoins pare-feux, définition des indicateurs et validation du plan par le RSSI.
+- **Semaines 2-3** : mise en place du pipeline d’ingestion (scripts d’automatisation, vérification d’intégrité) et tests en environnement pré-production.
+- **Semaine 4** : déploiement progressif (pare-feux périmétriques priorisés), monitoring rapproché et collecte des retours utilisateurs.
+- **Semaine 5** : extension aux zones internes critiques, revue des incidents, ajustements de règles et validation finale par le CAB.
 
 ### Allocation des ressources
-- Précisez les ressources nécessaires à l'intégration.
+- 1 Mainteneur Data-Shield (fournisseur de la blocklist) pour la coordination et la communication des mises à jour.
+- 2 Ingénieurs Opérations Sécurité pour l’automatisation et la supervision du déploiement.
+- 1 Ingénieur Réseau pour l’optimisation des performances et des limites de taille de tables (50k/130k IP selon équipement).【F:README.md†L69-L99】
+- Support conformité/GDPR pour la documentation réglementaire et les audits.
+- Infrastructure : référentiel Git interne, serveurs d’automatisation (Ansible/GitLab CI), monitoring (Prometheus, SIEM).
 
 ### Plan de communication
-- Décrivez comment la communication sera gérée tout au long du projet.
+- Notifications hebdomadaires aux équipes SOC/Réseau sur les volumes d’IP ajoutées/supprimées et incidents bloqués.
+- Alertes immédiates (mail + Teams) en cas d’indisponibilité du flux ou de changement critique communiqué par Laurent Minne.
+- Rapport mensuel de conformité partagé avec la Direction Cybersécurité et le RSSI incluant indicateurs de réduction d’attaques et cas de faux positifs traités.
 
 # Suivi et révision
 
 ### Mécanismes de suivi
-- Décrivez comment l'intégration sera suivie.
+- Tableau de bord SIEM consolidant les tentatives bloquées par la blocklist et comparant les statistiques avant/après intégration.
+- Surveillance continue des jobs d’ingestion (retour code, taille des fichiers, empreinte) avec alerting 24/7.
+- Revue hebdomadaire des IP exclues pour s’assurer du respect de la politique de rétention de 60 jours.【F:README.md†L37-L57】
 
 ### Processus d'examen
-- Mettez en place un processus permettant d'examiner l'efficacité de la Blocklist.
+- Revue trimestrielle par le RSSI et le Responsable Conformité pour évaluer l’efficacité du flux, ajuster les politiques de blocage et mettre à jour les procédures.
+- Audit annuel ISO 27001/NIS2 pour vérifier la traçabilité des mises à jour, la conformité GDPR et l’adéquation des contrôles techniques.
+- Post-mortem systématique après tout incident majeur lié au flux (faux positifs critiques ou indisponibilité prolongée) avec plan d’actions suivi.
 
 # Annexes
 
 ### Modèle RACI
-- Incluez un tableau détaillé du modèle RACI.
-
-### Documentation supplémentaire
-- Fournissez des liens vers de la documentation supplémentaire, telle que votre référentiel GitHub.
-
-# Exemple de modèle RACI
-
 | **Tâche** | **Responsable** | **Approbateur** | **Consulté** | **Informé** |
 |---|---|---|---|---|
-| Élaboration des politiques | Équipe informatique | RSSI | Service juridique | Direction |
-| Évaluation des risques | Équipe chargée des risques | Responsable de la sécurité des systèmes d'information | Équipe informatique | Direction |
-| Planification de l'intégration | Chef de projet | Directeur informatique | Équipe informatique | Toutes les parties prenantes |
-| Intégration de la liste noire | Équipe informatique | RSSI | Équipe de sécurité | Direction |
-| Surveillance et rapports | Équipe de sécurité | RSSI | Équipe informatique | Toutes les parties prenantes |
+| Publication quotidienne de la blocklist | Laurent Minne | RSSI | Équipe Opérations Sécurité | Direction Cybersécurité |
+| Validation technique et tests | Équipe Opérations Sécurité | RSSI | Équipe Réseau | Responsable Conformité IT |
+| Déploiement pare-feux (Fortinet, Palo Alto, etc.) | Équipe Opérations Sécurité | Directeur Infrastructure | Équipe Réseau | SOC |
+| Gestion des exceptions/faux positifs | Équipe Opérations Sécurité | RSSI | Support Client, Responsable Conformité IT | Direction Cybersécurité |
+| Suivi des indicateurs et reporting | Responsable Conformité IT | RSSI | SOC | Direction Générale |
+| Audits et revues annuelles | Responsable Conformité IT | RSSI | Laurent Minne, Équipe Opérations Sécurité | Direction Générale |
+
+### Documentation supplémentaire
+- Référentiel GitHub Data-Shield IPv4 Blocklist : https://github.com/duggytuxy/Data-Shield_IPv4_Blocklist
+- Tutoriels d’intégration par fournisseur (Fortinet, Check Point, Palo Alto, etc.) listés dans le README du projet.【F:README.md†L101-L132】
 
 # Prochaines étapes
 
 ### Créer le document
-- Utilisez un outil de traitement de texte tel que Microsoft Word pour créer le document.
+- Migrer ce canevas dans l’espace documentaire de l’entreprise (Confluence ou SharePoint) et intégrer les annexes complémentaires (procédures d’automatisation, scripts Ansible, registres GDPR).
 
 ### Remplir les sections
-- Remplissez chaque section en suivant les instructions fournies.
+- Compléter les parties spécifiques à l’entreprise : inventaire des pare-feux concernés, responsables nominatifs, liens vers les procédures internes (ITSM, SOC, réponse à incident).
 
 ### Révision et approbation
-- Faites réviser et approuver le document par les parties prenantes concernées.
+- Soumettre le document au CAB sécurité pour validation formelle, obtenir l’approbation du RSSI et de la Direction Cybersécurité, puis diffuser la version approuvée aux parties prenantes.
 
 ### Mise en œuvre
-- Suivez le plan d'intégration décrit dans le document.
+- Exécuter le plan d’intégration décrit ci-dessus, suivre les indicateurs définis et déclencher les revues périodiques conformément aux exigences de conformité.


### PR DESCRIPTION
## Summary
- remplacer le canevas générique du document de sécurité par un contenu adapté au projet Data-Shield IPv4 Blocklist
- détailler la politique de gouvernance, les rôles, l’évaluation des risques et le plan d’intégration à partir des informations du README
- enrichir les annexes avec un modèle RACI spécifique et les références de documentation applicables

## Testing
- Not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68dacca59028832f8d769c6d96330d37